### PR TITLE
Reference atom feed for news agregators

### DIFF
--- a/blog/pelicanconf.py
+++ b/blog/pelicanconf.py
@@ -13,15 +13,15 @@ TIMEZONE = 'America/Los_Angeles'
 DEFAULT_LANG = 'en'
 
 # Feed generation is usually not desired when developing
-FEED_ALL_ATOM = None
+FEED_ALL_ATOM = 'feeds/all.atom.xml'
 CATEGORY_FEED_ATOM = None
 TRANSLATION_FEED_ATOM = None
 AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
 # Social widget
-SOCIAL = (('You can add links in your config file', '#'),
-          ('Another social link', '#'),)
+SOCIAL = (('Twitter', 'https://twitter.com/Docathon'),
+          ('GitHub', 'https://github.com/docathon'),)
 
 DEFAULT_PAGINATION = 3
 


### PR DESCRIPTION
Also link to twitter and github account, but that's displayed nowhere on the pages. 