### PR TITLE
Better wording for hosts

### DIFF
--- a/blog/content/pages/hosts.md
+++ b/blog/content/pages/hosts.md
@@ -9,12 +9,24 @@ Summary: Information about how to help with the docathon.
 
 # Hosts
 
-Here is a list of organizations / groups that are holding docathon parties during the week.
 
-If you'd like to host your own remote docathon, [click here](hosting.html).
+While the Docathon is primarly a remote event, where opensource developers
+choose to focus on documentation for a specific week of the year, some will
+gather around for tutorials, hack together on a specific
+project or simply share a good time amongst documentation-lovers!
+
+Here is a list of organizations / groups that are holding docathon parties
+during the week. You are welcome to host your own Docathon, [click here](hosting.html).
+If you'd like join one of these locations, check out the details of the
+specific events. Don't forget to register if necessary!
 
   - [BIDS, UC Berkeley, CA](hosts/bids.html)
   - [eScience Institute, UW Seattle, WA](hosts/uwescience.html)
   - [Digital Fellows (GCDI), The Graduate Center, NY](hosts/gc.html)
 
-We have a [slack channel](https://docathon.slack.com) for communicating before and during the week. You can [request an invite](https://docathon.herokuapp.com/) here, or go directly to [https://docathon.slack.com](https://docathon.slack.com) if you already have a login.
+If you are doing a remote Docathon, but would like to be part of a greater
+community, we have a [slack channel](https://docathon.slack.com) for
+communicating before and during the week. You can [request an
+invite](https://docathon.herokuapp.com/) here, or go directly to
+[https://docathon.slack.com](https://docathon.slack.com) if you already have a
+login.


### PR DESCRIPTION
The hosts page was a bit sparse. I added more details on the hosts and specified that the docathon was primarily a remote location.