### PR TITLE
Add link to clawpack issues

### DIFF
--- a/blog/content/pages/participate.md
+++ b/blog/content/pages/participate.md
@@ -33,7 +33,7 @@ Here are some Projects that have already signed in :
 ---
 * [hdbscan](http://hdbscan.readthedocs.io)
 * [MNE-python](https://mne-tools.github.io/stable/index.html)
-* [Clawpack](http://clawpack.org)
+* [Clawpack](http://clawpack.org) - [issues](https://github.com/clawpack/doc/issues?q=is%3Aissue+is%3Aopen+label%3Adocathon)
 * [scikit-image](http://scikit-image.org)
 * [yt](http://yt-project.org/doc)
 * [Pandas](http://pandas.pydata.org/pandas-docs/stable/)


### PR DESCRIPTION
From our documentation it's not easy to find the clawpack/doc repository where the docathon issues are listed, so I think adding this link might help, if it doesn't look too cluttered.